### PR TITLE
Are tests flaky on windows?

### DIFF
--- a/tests/server-client/setup_run.sh
+++ b/tests/server-client/setup_run.sh
@@ -16,6 +16,7 @@ if [ -n "$IS_WINDOWS" ]; then
     UV=$HOME/.rye/uv/*/uv
     (cd server; $UV venv; $UV pip install -r pyproject.toml)
     (cd client; $UV venv; $UV pip install -r pyproject.toml)
+    sleep 1
 else
     $RYE sync --pyproject $SPROJ
     $RYE sync --pyproject $CPROJ


### PR DESCRIPTION
There was a spurious error after merge on the windows tester, but no clear reason why.

https://github.com/bluss/pyproject-local-kernel/actions/runs/8410754188