### PR TITLE
Enable debugger for kernel

### DIFF
--- a/data/kernel.json
+++ b/data/kernel.json
@@ -1,1 +1,8 @@
-{"argv": ["python", "-m", "pyproject_local_kernel", "-f", "{connection_file}"], "display_name": "Pyproject Local", "language": "python"}
+{
+  "argv": ["python", "-m", "pyproject_local_kernel", "-f", "{connection_file}"],
+  "display_name": "Pyproject Local",
+  "language": "python",
+  "metadata": {
+    "debugger": true
+  }
+}


### PR DESCRIPTION
Set metadata.debugger=true in the kernel so that it transparently supports debugging just like ipykernel itself does.

Requires ipykernel>=6 (in the notebook project), but older ipykernel 5 will still work, jupyterlab will probe if it has the debugging feature.