### PR TITLE
In tests: Without relative path workaround for windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   tests-linux:

--- a/tests/server-client/server/pyproject.toml
+++ b/tests/server-client/server/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = [
     # Note, the extra indirection at the end is a workaround for windows
-    "pyproject-local-kernel @ file:///${PROJECT_ROOT}/../../../../pyproject-local-kernel",
+    "pyproject-local-kernel @ file:///${PROJECT_ROOT}/../../..",
     "papermill>=2.5.0",
     "jupytext>=1.16.1",
 ]


### PR DESCRIPTION
The problem from commit 11e59f5713caebec91ad80d28b314162bd2a071c is now solved in rye 0.32 and uv 0.1.26.