### PR TITLE
Basic Uv support

### DIFF
--- a/src/pyproject_local_kernel/__main__.py
+++ b/src/pyproject_local_kernel/__main__.py
@@ -91,6 +91,7 @@ def start_fallback_kernel(project_kind: ProjectKind):
         "",
         "Use a command such as one of these to start:",
         "!rye init --virtual",
+        "!uv init",
         "!pdm init",
         "!poetry new .",
         "!hatch new",
@@ -110,6 +111,13 @@ def start_fallback_kernel(project_kind: ProjectKind):
         sync_kernel_env_messages += [
             "Run this:",
             "!rye add --sync ipykernel",
+            "",
+            "Then restart the kernel to try again.",
+        ]
+    elif project_kind == ProjectKind.Uv:
+        sync_kernel_env_messages += [
+            "Run this:",
+            "!uv add ipykernel",
             "",
             "Then restart the kernel to try again.",
         ]

--- a/tests/identify/uv/pyproject.toml
+++ b/tests/identify/uv/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "uv"
+version = "0.1.0"
+description = "Add your description here"
+dependencies = []
+
+[tool.uv]
+dev-dependencies = []

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -9,6 +9,7 @@ from pyproject_local_kernel import identify
     ("tests/identify/poetry", ProjectKind.Poetry),
     ("tests/identify/pdm", ProjectKind.Pdm),
     ("tests/identify/hatch", ProjectKind.Hatch),
+    ("tests/identify/uv", ProjectKind.Uv),
     ("tests/identify/broken", ProjectKind.InvalidData),
     ("tests/identify/unknown", ProjectKind.Unknown),
 ])


### PR DESCRIPTION
Select Uv if tool.uv is set and no other project manager is detected.

`uv run --with ipykernel` would be great for this usecase, but `uv run` can't be used yet (See #13 for details). 