### PR TITLE
Add configuration use-venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ figure out which kind of project it is:
 - Poetry
 - Hatch
 - Pdm
-- Custom configuration (for other setups)
+- Uv
+- Custom command (for other setups)
+- Use venv at path (for other setups)
 
 ## Quick Start
 
@@ -67,9 +69,15 @@ steps to get it working. Example below is for Rye.
 
 ## Configuration
 
-By default python from the local pyproject is run (using rye run, poetry run, etc.).
-A custom command can be configured in `pyproject.toml` - the pyproject file closest
-to the notebook is used (and no other means of configuration are supported).
+Only one of the custom command and virtualenv path configurations can be used
+at a time.
+
+### Custom Command
+
+By default python from the local pyproject is run (using rye run, poetry run,
+etc.). A custom command can be configured in `pyproject.toml` - the pyproject
+file closest to the notebook is used (and no other means of configuration are
+supported).
 
 The key `tool.pyproject-local-kernel.python-cmd` should be a command that runs
 python in the virtual environment you want to use for the project.
@@ -78,6 +86,11 @@ python in the virtual environment you want to use for the project.
 [tool.pyproject-local-kernel]
 python-cmd = ["my", "custom", "python"]
 ```
+
+### Virtualenv Path
+
+The key `tool.pyproject-local-kernel.use-venv` can be a path to a virtualenv,
+relative to the pyproject.toml file, which should be used.
 
 ## Project Status
 

--- a/tests/identify/use-venv/pyproject.toml
+++ b/tests/identify/use-venv/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "use-venv"
+version = "0.1.0"
+description = "Add your description here"
+dependencies = []
+requires-python = ">= 3.0"
+
+[tool.pyproject-local-kernel]
+use-venv = ".myvenv"

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -1,3 +1,6 @@
+import pathlib
+import os
+
 import pytest
 
 from pyproject_local_kernel import ProjectKind
@@ -26,6 +29,20 @@ def test_custom(path, cmd):
     pd = identify(path)
     assert pd.get_python_cmd() == cmd
     assert pd.path is not None and pd.path.name == "pyproject.toml"
+
+
+@pytest.mark.parametrize("path,unix_cmd,win_cmd", [
+    ("tests/identify/use-venv", ".myvenv/bin/python", r".myvenv\Scripts\python.exe")
+])
+def test_use_venv(path, unix_cmd, win_cmd):
+    pd = identify(path)
+    expected = win_cmd if is_windows() else unix_cmd
+    assert pd.get_python_cmd() == [pathlib.Path(expected)]
+    assert pd.path is not None and pd.path.name == "pyproject.toml"
+
+
+def is_windows():
+    return os.name == "nt"
 
 
 @pytest.mark.parametrize("path", [


### PR DESCRIPTION
### Virtualenv Path

The key `tool.pyproject-local-kernel.use-venv` can be a path to a virtualenv,
relative to the pyproject.toml file, which should be used.