### PR TITLE
Add workaround for hatch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
     - name: Install Uv
       run: |
         rye tools install -f uv
+        rye tools install -f hatch
     - name: Tests
       run: |
         make test-all
@@ -43,6 +44,7 @@ jobs:
       shell: bash
       run: |
         rye tools install -f uv
+        rye tools install -f hatch
     - name: Tests
       run: |
         make test-all ARGS='"-ktests"'

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ If this is set then it overrides the default command.
 
 ```toml
 [tool.pyproject-local-kernel]
-python-cmd = ["hatch", "env", "run", "python"]
+python-cmd = ["uv", "run", "--with", "ipykernel", "python"]
 ```
 
 ### `use-venv`
@@ -149,6 +149,22 @@ other method to install it.)
   `ipykernel` is used even if it's not already in the project(!). However, note that
   it uses an ephemeral virtual environment for ipykernel in that case. Add
   ipykernel to the project to avoid this.
+
+### PDM
+
+- PDM is detected if pyproject.toml contains `tool.pdm`
+
+### Hatch
+
+- Hatch is detected if pyproject.toml contains `tool.hatch.envs`
+
+- By default it calls out to `hatch env find`, to find the default virtualenv,
+  and runs from there. `hatch run` should not be used directly because
+  it's not compatible with how kernel interrupts work (as of this writing).
+
+- It's best to create the hatch project, add ipykernel as dependency and sync
+  dependencies in a terminal before starting (it does not work so well with
+  shell commands in a notebook).
 
 ## Project Status
 

--- a/src/pyproject_local_kernel/__main__.py
+++ b/src/pyproject_local_kernel/__main__.py
@@ -37,7 +37,7 @@ def main():
     logging.basicConfig(level=logging.INFO, format=f"{MY_TOOL_NAME}: %(message)s")
 
     find_project = identify(Path.cwd())
-    python_cmd = find_project.get_python_cmd(allow_fallback=True)
+    python_cmd = find_project.get_python_cmd(allow_fallback=True, allow_hatch_workaround=True)
 
     launched = False
     failure_to_start_msg = ""

--- a/tests/server-client/client-hatch/pyproject.toml
+++ b/tests/server-client/client-hatch/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "client-hatch"
+version = "1"
+description = ''
+requires-python = ">=3.8"
+keywords = []
+authors = [
+]
+dependencies = [
+    "ipykernel>=6",
+    "jinja2",
+]
+
+[project.urls]
+
+[tool.hatch.envs.default]
+installer = "uv"
+
+[tool.hatch.build.targets.wheel]
+bypass-selection = true

--- a/tests/server-client/setup_run.sh
+++ b/tests/server-client/setup_run.sh
@@ -26,11 +26,16 @@ for dir in ${directories[@]} ; do
     (cd "$dir";
         cp uv.lock uv.lock.orig;
         $UV python pin "$PYVERSION";
-        $UV sync $VERBOSE $UPDATE ;
+        $UV sync --reinstall-package pyproject-local-kernel $VERBOSE $UPDATE ;
     )
 done
 
-for nbdir in client-rye client-uv ; do
+# ensure client-hatch is synced
+(cd client-hatch;
+    hatch env run -- python -c "";
+)
+
+for nbdir in client-rye client-uv client-hatch ; do
     # convert to ipynb
     cp -v ./notebook.py $nbdir/
     $RYE run --pyproject $SPROJ jupytext --to ipynb $nbdir/notebook.py

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -1,5 +1,6 @@
 import pathlib
 import os
+import shutil
 
 import pytest
 
@@ -30,6 +31,19 @@ def test_ident(path, expected):
 def test_custom(path, cmd):
     pd = identify(path)
     assert pd.get_python_cmd() == cmd
+    assert pd.path is not None and pd.path.name == "pyproject.toml"
+
+
+@pytest.mark.parametrize("path", [
+    "tests/identify/hatch",
+])
+def test_hatch(path):
+    if not shutil.which("hatch"):
+        pytest.skip("Skip: hatch not installed")
+    pd = identify(path)
+    cmd = pd.get_python_cmd(allow_hatch_workaround=True)
+    assert cmd and len(cmd) == 1
+    assert isinstance(cmd[0], pathlib.Path)
     assert pd.path is not None and pd.path.name == "pyproject.toml"
 
 


### PR DESCRIPTION
`hatch run` is killed by SIGINT, but jupyter uses SIGINT to interrupt the kernel (cancel running computation without quitting the kernel). `hatch run` “seems” to work for
jupyterlab, which is why it was added, but on further use it's clear the kernel would die
each time stop was used (should normally just cancel running computation).

Work around this by using hatch env find then launching python from that environment.