### PR TITLE
better data model for configuration

### DIFF
--- a/src/pyproject_local_kernel/configdata.py
+++ b/src/pyproject_local_kernel/configdata.py
@@ -1,0 +1,54 @@
+import dataclasses
+import logging
+import typing as t
+
+_logger = logging.getLogger(__name__)
+
+
+def _to_skewer_case(name: str):
+    return name.replace("_", "-")
+
+
+def _type_check(type_annot, obj):
+    """
+    Yes I know, ad-hoc type check of type annotations.
+    Supports List, Union, Optional as needed.
+    """
+    args = t.get_args(type_annot)
+    orig = t.get_origin(type_annot) or type_annot
+    if args != () and (orig == t.Union or orig == t.Optional):
+        return any(_type_check(arg, obj) for arg in args)
+    elif args != () and orig == list:
+        return _type_check(list, obj) and all(_type_check(args[0], elt) for elt in obj)
+    ret = isinstance(obj, orig)
+    return ret
+
+
+@dataclasses.dataclass
+class Config:
+    """
+    pyproject tool.MY_TOOL_NAME section
+    """
+
+    python_cmd: t.Optional[t.Union[str, t.List[str]]] = None
+    use_venv: t.Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: t.Dict[str, t.Any]):
+        kwargs = {}
+        used_configs = set()
+        for field in dataclasses.fields(cls):
+            config_name = _to_skewer_case(field.name)
+            try:
+                config_value = data[config_name]
+                if not _type_check(field.type, config_value):
+                    raise TypeError(f"invalid config {config_name} = {config_value!r}, expected value of type {field.type}")
+                kwargs[field.name] = config_value
+                used_configs.add(config_name)
+            except KeyError:
+                pass
+        for unknown_config_key in set(data).difference(used_configs):
+            _logger.warning("Ignoring unknown configuration key %r", unknown_config_key)
+        return cls(**kwargs)
+
+

--- a/tests/identify/custom/pyproject.toml
+++ b/tests/identify/custom/pyproject.toml
@@ -15,3 +15,4 @@ dev-dependencies = []
 
 [tool.pyproject-local-kernel]
 python-cmd = ["my", "cmd"]
+not-valid = 1

--- a/tests/identify/custom_broken2/pyproject.toml
+++ b/tests/identify/custom_broken2/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "broken2"
+version = "0.1.0"
+description = "Add your description here"
+dependencies = []
+
+[tool.pyproject-local-kernel]
+python-cmd = ["hey", 1]

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -75,11 +75,22 @@ def is_windows():
 
 @pytest.mark.parametrize("path", [
     "tests/identify/custom_broken",
+    "tests/identify/custom_broken2",
 ])
 def test_custom_error(path, caplog):
     # Test log error
     identify(path)
-    assert any('Is not a list or string' in rec.message for rec in caplog.records)
+    assert any("invalid config python-cmd =" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.parametrize("path", [
+    "tests/identify/custom",
+])
+def test_custom_ignored_key(path, caplog):
+    # Test log error
+    identify(path)
+    assert any("unknown configuration key 'not-valid'" in rec.message for rec in caplog.records)
+
 
 def test_no_project(tmp_path):
     pd = identify(tmp_path)


### PR DESCRIPTION
Simple data model but more correct model for the
tool.pyproject-local-kernel section.

Reason for ad-hoc type check function: less dependencies that might force us to update requires-python or cause the package to break.