### PR TITLE
Fix windows kernel interrupts finally

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -49,6 +49,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 BSD 3-Clause License
 
+Copyright (c) 2024, Ulrik Sverdrup "bluss"
 Copyright (c) 2015, IPython Development Team
 
 All rights reserved.


### PR DESCRIPTION
As a follow-up to #30, this finally fixes kernel interrupts in windows, so that it works in jupyterlab. I had to spin up a windows VM to debug & confirm the fix. :tada: :tada: 

I don't know right know why the old code here didn't work -- note the parentpoller.py code from ipykernel is very old -- it calls interrupt_main() but that does not trigger our signal handler. It is replaced by a callback here instead.