### PR TITLE
Modify relative path in internal dependency

### DIFF
--- a/tests/server-client/server/pyproject.toml
+++ b/tests/server-client/server/pyproject.toml
@@ -32,4 +32,4 @@ package = false
 
 [tool.uv.workspace]
 [tool.uv.sources]
-pyproject-local-kernel = { path = "../../../../pyproject-local-kernel" }
+pyproject-local-kernel = { path = "../../../" }


### PR DESCRIPTION
We shouldn't assume the source directory has this exact name, then tests don't work when running in a source snapshot with a different name.