### PR TITLE
 Add test for Pyproject Local (use-venv)

### DIFF
--- a/src/pyproject_local_kernel/provisioner.py
+++ b/src/pyproject_local_kernel/provisioner.py
@@ -25,7 +25,7 @@ Add `ipykernel` as a dependency in your project and update the virtual environme
 class PyprojectKernelProvisioner(LocalProvisioner):
     # only active if metadata pyproject_local_kernel.venv=true
     use_venv = Unicode(default_value=".venv", allow_none=True,
-                       help="Default setting for use-venv for projects using the kernel").tag(config=True)
+                       help="Default setting for use-venv for projects using the 'use-venv' kernel").tag(config=True)
     sanity_check = Bool(default_value=True, help="Enable sanity check for 'ipykernel' package in environment").tag(config=True)
     python_kernel_args = List[str](allow_none=False, help="Arguments for kernel process")
 

--- a/tests/server-client/notebook_use_venv.py
+++ b/tests/server-client/notebook_use_venv.py
@@ -1,0 +1,26 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.14.6
+#   kernelspec:
+#     display_name: Pyproject Local
+#     language: python
+#     name: pyproject_local_kernel_use_venv
+# ---
+
+# %%
+import sys
+
+# %%
+sys.executable
+
+# %%
+sys.version_info
+
+# %%
+# try our local dependency
+import jinja2

--- a/tests/test_jupyter_kernel.py
+++ b/tests/test_jupyter_kernel.py
@@ -106,13 +106,14 @@ class ScenarioSetup:
             return proc
 
 
-@pytest.mark.parametrize("scenario", [
-    "rye",
-    "uv",
-    "hatch",
-    "venv",
+@pytest.mark.parametrize("scenario,notebook", [
+    ("rye", "notebook.py"),
+    ("uv", "notebook.py"),
+    ("uv", "notebook_use_venv.py"),
+    ("hatch", "notebook.py"),
+    ("venv", "notebook.py"),
 ])
-def test_project_manager(scenario: str, python_version: str, scenario_setup: ScenarioSetup):
+def test_project_manager(scenario: str, notebook: str | None,python_version: str, scenario_setup: ScenarioSetup):
     """
     Test papermill and pyproject-local-kernel for notebook side vs uv / rye / hatch / venv for project side
     """
@@ -121,7 +122,7 @@ def test_project_manager(scenario: str, python_version: str, scenario_setup: Sce
 
     update = python_version == "3.12"
 
-    scenario_setup.scenario(scenario, update)
+    scenario_setup.scenario(scenario, update, notebook=notebook)
     proc = scenario_setup.papermill()
     returncode = proc.returncode
 

--- a/tests/test_provisioner.py
+++ b/tests/test_provisioner.py
@@ -55,12 +55,12 @@ KS_VENV = KERNEL_SPECS[1]
 ], indirect=["kernel_spec"])
 def test_pre_launch(scenario: str, expected, sanity: bool, kernel_spec: KernelSpec,
                     tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    prov = PyprojectKernelProvisioner()
-    prov.use_venv = ".venv"
-    prov.python_kernel_args = ["command", "-f", "{connection_file}"]
-    prov.sanity_check = sanity
-    prov.kernel_spec = kernel_spec
-
+    prov = PyprojectKernelProvisioner(
+        use_venv=".venv",
+        sanity_check=sanity,
+        kernel_spec=kernel_spec,
+        python_kernel_args=["command", "-f", "{connection_file}"],
+    )
     cwd = tmp_path
 
     if scenario:


### PR DESCRIPTION
Add papermill test for pyproject_local_kernel_use_venv

This follows-up on the change in cb90a2064576d8e58645ad9577a7653a94780065
where a separate kernelspec **Pyproject Local (use-venv)** was added:

For convenience, add separate kernelspec for direct use of .venv.

pyproject.toml configuration is still primary - it decides which
configuration a Pyproject Local kernelspec will run. This new kernelspec
just has a default of `use-venv = ".venv"`.

And regular jupyter configuration methods apply, which means that
`PyprojectKernelProvisioner.use_venv` sets the default virtual environment location,
but `pyproject.toml` configuration is still preferred because it
is more portable between different collaborators on the same project.

![bild](https://github.com/user-attachments/assets/222df0e0-4c71-4d63-9d19-3681938edec6)

And because these are Jupyter objects, it is configurable

```
#------------------------------------------------------------------------------
# PyprojectKernelProvisioner(LocalProvisioner) configuration
#------------------------------------------------------------------------------
## Enable sanity check for 'ipykernel' package in environment
#  Default: True
# c.PyprojectKernelProvisioner.sanity_check = True

## Default setting for use-venv for projects using the kernel
#  Default: '.venv'
# c.PyprojectKernelProvisioner.use_venv = '.venv'
```