### PR TITLE
Launch fallback using python -m

### DIFF
--- a/src/pyproject_local_kernel/__main__.py
+++ b/src/pyproject_local_kernel/__main__.py
@@ -18,8 +18,6 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import sys
-
-
 from pyproject_local_kernel.main import main
 
 sys.exit(main())

--- a/src/pyproject_local_kernel/provisioner.py
+++ b/src/pyproject_local_kernel/provisioner.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 import os
 import subprocess
+import sys
 import time
 import typing as t
 
@@ -94,7 +95,7 @@ class PyprojectKernelProvisioner(LocalProvisioner):
             new_kwargs = self._pplk_pre_launch(**kwargs)
         except (OSError, RuntimeError) as exc:
             # an error was encountered, run the fallback kernel instead to present the error
-            self.kernel_spec.argv[:] = ["pyproject_local_kernel", f"--fallback-kernel={exc}"] + self.python_kernel_args
+            self.kernel_spec.argv[:] = [sys.executable, "-m", "pyproject_local_kernel", f"--fallback-kernel={exc}"] + self.python_kernel_args
             new_kwargs = kwargs
         except Exception:
             raise  # show to user

--- a/tests/test_provisioner.py
+++ b/tests/test_provisioner.py
@@ -86,10 +86,10 @@ def test_pre_launch(scenario: str, expected, sanity: bool, kernel_spec: KernelSp
         uv_cmd = list(ProjectKind.Uv.python_cmd() or ["x"])
         assert python_cmd[:len(uv_cmd)] == uv_cmd
     elif expected == Expected.Fallback:
-        assert python_cmd[1] == "--fallback-kernel=not sane"
+        assert python_cmd[3] == "--fallback-kernel=not sane"
     elif expected == Expected.NoPyproject:
-        assert python_cmd[1].startswith("--fallback-kernel")
-        assert 'no pyproject.toml' in python_cmd[1]
+        assert python_cmd[3].startswith("--fallback-kernel")
+        assert 'no pyproject.toml' in python_cmd[3]
     else:
         raise NotImplementedError
 


### PR DESCRIPTION
Launch fallback kernel using python -m, which is the most portable (to 'unactivated' virtual environments).

Fix sys.argv cleaning for the fallback kernel. It didn't cause a problem yet, but why not is also not clear.