### PR TITLE
Provisioner and sanity check improvements

### DIFF
--- a/src/pyproject_local_kernel/provisioner.py
+++ b/src/pyproject_local_kernel/provisioner.py
@@ -19,7 +19,7 @@ from pyproject_local_kernel.configdata import Config
 
 _SCRIPT_CHECK_HAS_KERNEL = """import importlib.util; raise SystemExit(not importlib.util.find_spec("ipykernel"))"""
 _MESSAGE_NO_PYPROJECT = """Could not start project - no pyproject.toml or malformed pyproject.toml?"""
-_MESSAGE_NO_IPYKERNEL = """Could not find `ipykernel` in environment.
+_MESSAGE_NO_IPYKERNEL_SANITY = """Sanity check: Could not find `ipykernel` in environment.
 Add `ipykernel` as a dependency in your project and update the virtual environment."""
 
 
@@ -118,7 +118,7 @@ class PyprojectKernelProvisioner(LocalProvisioner):
                 subprocess.run(sanity_cmd, check=True, cwd=cwd, env=sanity_env)
             except (subprocess.CalledProcessError, OSError) as exc:
                 self.__log(logging.ERROR, "failed sanity check: %s", exc)
-                raise RuntimeError(_MESSAGE_NO_IPYKERNEL)
+                raise RuntimeError(_MESSAGE_NO_IPYKERNEL_SANITY)
         finally:
             self._log_debug("used %.3f s on sanity check", (time.time() - st))
 

--- a/src/pyproject_local_kernel/provisioner.py
+++ b/src/pyproject_local_kernel/provisioner.py
@@ -123,7 +123,7 @@ class PyprojectKernelProvisioner(LocalProvisioner):
             self._log_debug("used %.3f s on sanity check", (time.time() - st))
 
     async def launch_kernel(self, cmd: t.List[str], **kwargs: t.Any) -> KernelConnectionInfo:
-        self._log_info("Launching %r", cmd)
+        self._log_info("Launching %r in cwd=%r", cmd, kwargs.get("cwd", None))
         self._log_debug("PATH=%r", kwargs.get("env", {}).get("PATH"))
 
         try:


### PR DESCRIPTION
- Set environment variable `PYPROJECT_LOCAL_KERNEL_SANITY_CHECK` when running sanity check (to see if ipykernel is in the environment). Custom scripts can handle this as they want
- Log working directory / cwd when starting kernel
  `Launching ['uv', 'run', ...] in cwd='/home/user/project/notebook1'`