### PR TITLE
Add configuration for sanity-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,20 @@ or sync required dependencies.
 use-venv = ".venv"
 ```
 
+### `sanity-check`
+
+If `true`, then run a check for `ipykernel` being installed in the project
+before starting the kernel process.
+
+**Default:** true<br>
+**Type:** `bool`<br>
+**Example:**
+
+```toml
+[tool.pyproject-local-kernel]
+sanity-check = true
+```
+
 
 ### `PyprojectKernelProvisioner`
 

--- a/src/pyproject_local_kernel/__init__.py
+++ b/src/pyproject_local_kernel/__init__.py
@@ -105,7 +105,7 @@ class ProjectDetection:
             return PythonEnvironment(cmd, venv_bin_dir)
 
         # configuration: python-cmd
-        python_cmd = self.config.python_cmd_normalized()
+        python_cmd = self.config.python_cmd
         if python_cmd is not None:
             return PythonEnvironment(python_cmd)
 

--- a/src/pyproject_local_kernel/__init__.py
+++ b/src/pyproject_local_kernel/__init__.py
@@ -223,10 +223,10 @@ def _identify_toml(data) -> t.Tuple[ProjectKind, t.Optional[Config], t.Optional[
         return ProjectKind.UseVenv, config, None
     for kind, func in IDENTIFY_FUNCTIONS.items():
         if func(data):
-            return kind, None, None
+            return kind, config, None
     if not has_project_table(data):
         return ProjectKind.InvalidData, None, "No valid project table"
-    return ProjectKind.Unknown, None, None
+    return ProjectKind.Unknown, config, None
 
 
 def identify(file):

--- a/src/pyproject_local_kernel/configdata.py
+++ b/src/pyproject_local_kernel/configdata.py
@@ -70,6 +70,7 @@ class Config(_PostInitTypeCheck):
 
     python_cmd: t.Optional[t.List[str]] = None
     use_venv: t.Optional[str] = None
+    sanity_check: t.Optional[bool] = None
 
     from_dict = classmethod(_dataclass_from_dict)
 

--- a/src/pyproject_local_kernel/configdata.py
+++ b/src/pyproject_local_kernel/configdata.py
@@ -68,12 +68,16 @@ class Config(_PostInitTypeCheck):
     pyproject tool.MY_TOOL_NAME section
     """
 
-    python_cmd: t.Optional[t.Union[str, t.List[str]]] = None
+    python_cmd: t.Optional[t.List[str]] = None
     use_venv: t.Optional[str] = None
 
     from_dict = classmethod(_dataclass_from_dict)
 
-    def python_cmd_normalized(self) -> list[str] | None:
+    def __post_init__(self):
+        self.python_cmd = self._python_cmd_normalized()
+        super().__post_init__()
+
+    def _python_cmd_normalized(self) -> list[str] | None:
         if isinstance(self.python_cmd, str):
             return shlex.split(self.python_cmd)
         return self.python_cmd

--- a/src/pyproject_local_kernel/configdata.py
+++ b/src/pyproject_local_kernel/configdata.py
@@ -12,6 +12,10 @@ def _to_skewer_case(name: str) -> str:
     return name.replace("_", "-")
 
 
+def _not_none(a: t.Any, b: t.Any) -> t.Any:
+    return a if a is not None else b
+
+
 def _type_check(type_annot: t.Any, obj: t.Any) -> bool:
     """
     Yes I know, ad-hoc type check of type annotations.
@@ -76,4 +80,6 @@ class Config(_PostInitTypeCheck):
 
     def merge_with(self, other: Config) -> Config:
         "Merge with self taking precedence over other"
-        return Config(python_cmd=self.python_cmd or other.python_cmd, use_venv=self.use_venv or other.use_venv)
+        values = {field.name: _not_none(getattr(self, field.name), getattr(other, field.name))
+                  for field in dataclasses.fields(self)}
+        return Config(**values)

--- a/src/pyproject_local_kernel/provisioner.py
+++ b/src/pyproject_local_kernel/provisioner.py
@@ -20,8 +20,10 @@ from pyproject_local_kernel.configdata import Config
 
 _SCRIPT_CHECK_HAS_KERNEL = """import importlib.util; raise SystemExit(not importlib.util.find_spec("ipykernel"))"""
 _MESSAGE_NO_PYPROJECT = """Could not start project - no pyproject.toml or malformed pyproject.toml?"""
-_MESSAGE_NO_IPYKERNEL_SANITY = """Sanity check: Could not find `ipykernel` in environment.
+_MESSAGE_SANITY = """Sanity check: Could not find `ipykernel` in environment"""
+_MESSAGE_SANITY_NO_IPYKERNEL = _MESSAGE_SANITY + """
 Add `ipykernel` as a dependency in your project and update the virtual environment."""
+
 
 
 class PyprojectKernelProvisioner(LocalProvisioner):
@@ -115,9 +117,12 @@ class PyprojectKernelProvisioner(LocalProvisioner):
             sanity_env["PYPROJECT_LOCAL_KERNEL_SANITY_CHECK"] = "1"
             try:
                 subprocess.run(sanity_cmd, check=True, cwd=cwd, env=sanity_env)
+            except OSError as exc:
+                self.__log(logging.ERROR, "failed sanity check: %s", exc)
+                raise RuntimeError(_MESSAGE_SANITY + f"\nError: {exc}")
             except (subprocess.CalledProcessError, OSError) as exc:
                 self.__log(logging.ERROR, "failed sanity check: %s", exc)
-                raise RuntimeError(_MESSAGE_NO_IPYKERNEL_SANITY)
+                raise RuntimeError(_MESSAGE_SANITY_NO_IPYKERNEL)
         finally:
             self._log_debug("used %.3f s on sanity check", (time.time() - st))
 

--- a/src/pyproject_local_kernel/provisioner.py
+++ b/src/pyproject_local_kernel/provisioner.py
@@ -58,13 +58,13 @@ class PyprojectKernelProvisioner(LocalProvisioner):
             self._log_debug("%s=%r", tname, getattr(self, tname, None))
 
         spec_use_venv = self.use_venv if self.is_use_venv_kernel else None
-        spec_config = Config(use_venv=spec_use_venv)
+        spec_config = Config(use_venv=spec_use_venv, sanity_check=self.sanity_check)
 
         if not self.python_kernel_args:
             raise RuntimeError("pyproject_local_kernel config missing from kernelspec")
 
         find_project = identify(cwd)
-        find_project.config = find_project.config.merge_with(spec_config).merge_with(Config.default())
+        find_project.config = find_project.config.merge_with(spec_config)
         self._log_debug("Found project %s in %s", find_project.kind, find_project.path)
         self._log_debug("with effective config %r", find_project.config)
 
@@ -86,7 +86,7 @@ class PyprojectKernelProvisioner(LocalProvisioner):
         python_cmd = list(map(str, python_environment.python_cmd))
         kernel_spec.argv[:] = python_cmd + self.python_kernel_args
 
-        if self.sanity_check:
+        if find_project.config.sanity_check:
             self._python_environment_sanity_check(find_project, python_cmd, cwd, env=kwargs.get("env"))
         return kwargs
 

--- a/src/pyproject_local_kernel/provisioner.py
+++ b/src/pyproject_local_kernel/provisioner.py
@@ -64,7 +64,7 @@ class PyprojectKernelProvisioner(LocalProvisioner):
             raise RuntimeError("pyproject_local_kernel config missing from kernelspec")
 
         find_project = identify(cwd)
-        find_project.config = find_project.config.merge_with(spec_config)
+        find_project.config = find_project.config.merge_with(spec_config).merge_with(Config.default())
         self._log_debug("Found project %s in %s", find_project.kind, find_project.path)
         self._log_debug("with effective config %r", find_project.config)
 

--- a/tests/identify/config_cmd/pyproject.toml
+++ b/tests/identify/config_cmd/pyproject.toml
@@ -16,3 +16,4 @@ dev-dependencies = []
 [tool.pyproject-local-kernel]
 python-cmd = ["my", "cmd"]
 not-valid = 1
+sanity_check = false

--- a/tests/identify/config_cmd_string/pyproject.toml
+++ b/tests/identify/config_cmd_string/pyproject.toml
@@ -6,4 +6,4 @@ dependencies = []
 requires-python = ">= 3.0"
 
 [tool.pyproject-local-kernel]
-python-cmd = "uv run --with 'custom string' -BI"
+python_cmd = "uv run --with 'custom string' -BI"

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -104,7 +104,7 @@ def test_custom_error(path, caplog):
 def test_custom_ignored_key(path, caplog):
     # Test log error
     identify(path)
-    assert any("unknown configuration key 'not-valid'" in rec.message for rec in caplog.records)
+    assert any("unknown (or duplicate) configuration key 'not-valid'" in rec.message for rec in caplog.records)
 
 
 def test_no_project(tmp_path: Path):

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -29,16 +29,17 @@ def test_ident(path, expected):
     assert pd.path is not None and pd.path.name == "pyproject.toml"
 
 
-@pytest.mark.parametrize("path,cmd", [
-    ("tests/identify/config_cmd", ["my", "cmd"]),
-    ("tests/identify/config_cmd_string", ['uv', 'run', '--with', 'custom string', '-BI']),
+@pytest.mark.parametrize("path,cmd,sanity", [
+    ("tests/identify/config_cmd", ["my", "cmd"], False),
+    ("tests/identify/config_cmd_string", ['uv', 'run', '--with', 'custom string', '-BI'], None),
     # uv must be on the path, then we pick this fallback
-    ("tests/identify/unknown", ["uv", "run", "--with", "ipykernel", "python"]),
+    ("tests/identify/unknown", ["uv", "run", "--with", "ipykernel", "python"], None),
 ])
-def test_custom(path, cmd):
+def test_custom_and_sanity(path, cmd, sanity):
     pd = identify(path)
     assert pd.get_python_cmd() == cmd
     assert pd.path is not None and pd.path.name == "pyproject.toml"
+    assert pd.config.sanity_check == sanity
 
 
 @pytest.mark.parametrize("path", [


### PR DESCRIPTION
- provisioner: Show detailed sanity check error
- add project configuration `sanity-check` (default true)
- accept either `sanity_check` or `sanity-check` (and so on for all config variables)