### PR TITLE
Test parent gone on windows

### DIFF
--- a/tests/test_jupyter_kernel.py
+++ b/tests/test_jupyter_kernel.py
@@ -174,7 +174,7 @@ def test_interrupt(python_version: str, scenario_setup: ScenarioSetup):
         raise
 
 
-@pytest.mark.skip
+@pytest.mark.skipif(sys.platform != "win32", reason="windows only because of ipykernel")
 def test_interrupt_parent_gone(scenario_setup: ScenarioSetup):
     scenario = "interrupt"
     papermill_args = "--execution-timeout 10"


### PR DESCRIPTION
On windows, there is a parent handle passed which can pass over processes (papermill -> uv run -> ipykernel) in this case.

In contrast on linux 1) ipykernel doesn't detect the parent is gone ever until bug ipykernel#517 is fixed (ipykernel v7.0.0 maybe?) and 2) it will never detect that papermill disappears if uv run is the direct parent, unfortunately.